### PR TITLE
fix src/Spotify.js link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This Application relies on [Fetch API](https://fetch.spec.whatwg.org/). And this
 
 ## How to Run
 
-1. First go to [Spotify Developers API](https://developer.spotify.com/web-api/) and create your Token. Then add your token on [src/spotify.js](src/spotify.js). **Remember that the token will expire in 60min**
+1. First go to [Spotify Developers API](https://developer.spotify.com/web-api/) and create your Token. Then add your token on [src/Spotify.js](src/Spotify.js). **Remember that the token will expire in 60min**
 2. Install the dependencies with `npm i`.
 3. Run your application with `npm start`.
 


### PR DESCRIPTION
Since the link was written in lowercase, it was going to a 404 page.